### PR TITLE
Fixed NullPointerException caused by child

### DIFF
--- a/v4/java/android/support/v4/widget/DrawerLayout.java
+++ b/v4/java/android/support/v4/widget/DrawerLayout.java
@@ -850,6 +850,9 @@ public class DrawerLayout extends ViewGroup {
     }
 
     boolean isContentView(View child) {
+        if (child == null) {
+            return true;
+        }
         return ((LayoutParams) child.getLayoutParams()).gravity == Gravity.NO_GRAVITY;
     }
 


### PR DESCRIPTION
Fixed NullPointerException caused by child, while having drawers on both the sides & one is opened.
