### PR TITLE
[TabLayout] Don't interupt pending animation, when distant tab was reselected

### DIFF
--- a/design/src/android/support/design/widget/TabLayout.java
+++ b/design/src/android/support/design/widget/TabLayout.java
@@ -1339,16 +1339,36 @@ public class TabLayout extends HorizontalScrollView {
                 if (position < mSelectedPosition) {
                     // We're going end-to-start
                     if (isRtl) {
-                        startLeft = startRight = targetLeft - offset;
+                        if (mIndicatorRight > targetLeft) {
+                            //don't interupt pending animation
+                            return;
+                        } else {
+                            startLeft = startRight = targetLeft - offset;
+                        }
                     } else {
-                        startLeft = startRight = targetRight + offset;
+                        if (mIndicatorLeft < targetRight) {
+                            //don't interupt pending animation
+                            return;
+                        } else {
+                            startLeft = startRight = targetRight + offset;
+                        }
                     }
                 } else {
                     // We're going start-to-end
                     if (isRtl) {
-                        startLeft = startRight = targetRight + offset;
+                        if (mIndicatorLeft < targetRight) {
+                            //don't interupt pending animation
+                            return;
+                        } else {
+                            startLeft = startRight = targetRight + offset;
+                        }
                     } else {
-                        startLeft = startRight = targetLeft - offset;
+                        if (mIndicatorRight > targetLeft) {
+                            //don't interupt pending animation
+                            return;
+                        } else {
+                            startLeft = startRight = targetLeft - offset;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I've noticed that animation of moving indicator, when adjacent tab is reselected, fluently continue. However, when distant tab is reselected, animation starts again and it should continue. 

This change prevents starting animation, when it's already pending.
