### PR TITLE
[Fix] Incorrectly positioned Accessibility Toast near ActionViewItem when FLAG_FULLSCREEN applied to Window

### DIFF
--- a/v7/appcompat/src/android/support/v7/internal/view/menu/ActionMenuItemView.java
+++ b/v7/appcompat/src/android/support/v7/internal/view/menu/ActionMenuItemView.java
@@ -251,13 +251,24 @@ public class ActionMenuItemView extends AppCompatTextView
         if (midy < displayFrame.height()) {
             // Show along the top; follow action buttons
             cheatSheet.setGravity(Gravity.TOP | GravityCompat.END, referenceX,
-                    screenPos[1] + height - displayFrame.top);
+                    height - getStatusBarHeight() + screenPos[1]);
         } else {
             // Show along the bottom center
             cheatSheet.setGravity(Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL, 0, height);
         }
         cheatSheet.show();
         return true;
+    }
+
+    private int getStatusBarHeight()
+    {
+        int result = 0;
+	int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
+	if (resourceId > 0)
+	{
+		result = getResources().getDimensionPixelSize(resourceId);
+	}
+	return result;
     }
 
     @Override


### PR DESCRIPTION
Positioning of Accessibility hints (Toasts) near ActionBar ActionView Items would be positioned too low in case WindowManager.LayoutParams.FLAG_FULLSCREEN flag had been applied to Window; The Toast would appear the status bar's height too low.
