### PR TITLE
Remove mController from FragmentManager

### DIFF
--- a/fragment/java/android/support/v4/app/FragmentManager.java
+++ b/fragment/java/android/support/v4/app/FragmentManager.java
@@ -519,7 +519,6 @@ final class FragmentManagerImpl extends FragmentManager implements LayoutInflate
 
     int mCurState = Fragment.INITIALIZING;
     FragmentHostCallback mHost;
-    FragmentController mController;
     FragmentContainer mContainer;
     Fragment mParent;
 


### PR DESCRIPTION
`mController` is never used in package `android.support.v4.app`, then I removed it.