### PR TITLE
[fix] #221387

### DIFF
--- a/design/src/android/support/design/widget/CoordinatorLayout.java
+++ b/design/src/android/support/design/widget/CoordinatorLayout.java
@@ -645,14 +645,13 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
                     continue;
                 }
                 final View other = getChildAt(j);
-                final LayoutParams otherLp = getResolvedLayoutParams(other);
-                if (otherLp.dependsOn(this, other, view)) {
+                if (lp.dependsOn(this, view, other)) {
                     if (!mChildDag.contains(other)) {
                         // Make sure that the other node is added
                         mChildDag.addNode(other);
                     }
                     // Now add the dependency to the graph
-                    mChildDag.addEdge(view, other);
+                    mChildDag.addEdge(other, view);
                 }
             }
         }


### PR DESCRIPTION
https://code.google.com/p/android/issues/detail?id=221387
Problem is that dependsOn is called on otherLp, but its `mAnchorDirectChild` can be empty. Should call dependsOn on lp, since lp.findAnchorView fills  `mAnchorDirectChild`