### PR TITLE
[fix] #63151548 Fixed devices crashing due to overriding methods with Icon parameter

### DIFF
--- a/v7/appcompat/src/android/support/v7/widget/AppCompatImageButton.java
+++ b/v7/appcompat/src/android/support/v7/widget/AppCompatImageButton.java
@@ -100,14 +100,6 @@ public class AppCompatImageButton extends ImageButton implements TintableBackgro
     }
 
     @Override
-    public void setImageIcon(@Nullable Icon icon) {
-        super.setImageIcon(icon);
-        if (mImageHelper != null) {
-            mImageHelper.applySupportImageTint();
-        }
-    }
-
-    @Override
     public void setImageURI(@Nullable Uri uri) {
         super.setImageURI(uri);
         if (mImageHelper != null) {

--- a/v7/appcompat/src/android/support/v7/widget/AppCompatImageView.java
+++ b/v7/appcompat/src/android/support/v7/widget/AppCompatImageView.java
@@ -110,14 +110,6 @@ public class AppCompatImageView extends ImageView implements TintableBackgroundV
     }
 
     @Override
-    public void setImageIcon(@Nullable Icon icon) {
-        super.setImageIcon(icon);
-        if (mImageHelper != null) {
-            mImageHelper.applySupportImageTint();
-        }
-    }
-
-    @Override
     public void setImageURI(@Nullable Uri uri) {
         super.setImageURI(uri);
         if (mImageHelper != null) {


### PR DESCRIPTION
> Samsung API 19 devices are known for this. I you override View class method with parameter of type that doesn't exist on API 19 it will crash. WindowInsets is a prime example. That's why we have WindowInsetsCompat and a listener hooked *into a platform listener*.

Same issue here but with `Icon` parameter. Since the impl calls through to `setImageDrawable` I just removed the superfluous `setImageIcon` overrides.

See https://issuetracker.google.com/issues/63151548